### PR TITLE
Add FlowM BlockWorld memory benchmark dataset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ mkdir -p pretrained_models/i3d && curl -L \
     -o pretrained_models/i3d/i3d_torchscript.pt
 ```
 
-For dataset downloads (DINO-WM, RT-1, CSGO), see [docs/datasets/README.md](docs/datasets/README.md).
+For dataset downloads (DINO-WM, RT-1, CSGO, BlockWorld), see [docs/datasets/README.md](docs/datasets/README.md).
 
 ## 🥷 Train your first model
 
@@ -139,7 +139,7 @@ NanoWM rollouts can be used directly for downstream applications, including long
 - **[docs/config_system.md](docs/config_system.md)** — Hydra config layout, overrides, environment variables
 - **[docs/training.md](docs/training.md)** — training workflow, design choices, ablation tables, all checkpoints
 - **[docs/evaluation.md](docs/evaluation.md)** — evaluation workflow, metric definitions, full result tables
-- **[docs/datasets/README.md](docs/datasets/README.md)** — DINO-WM / RT-1 / CSGO formats, downloads, splits
+- **[docs/datasets/README.md](docs/datasets/README.md)** — DINO-WM / RT-1 / CSGO / BlockWorld formats, downloads, splits
 - **[docs/applications/planning.md](docs/applications/planning.md)** — MPC + CEM model-predictive control
 - **[docs/applications/long_rollout.md](docs/applications/long_rollout.md)** — long-horizon autoregressive rollout
 - **[docs/applications/video_to_3d.md](docs/applications/video_to_3d.md)** — Depth Anything 3 point cloud pipeline

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ docs/
 ├── training.md           (training workflow + design choices + ablation tables)
 ├── evaluation.md         (eval workflow + main result tables + sampling)
 ├── datasets/
-│   └── README.md         (DINO-WM, RT-1, CSGO formats and configs)
+│   └── README.md         (DINO-WM, RT-1, CSGO, BlockWorld formats and configs)
 └── applications/
     ├── planning.md       (MPC + CEM model-predictive control)
     ├── long_rollout.md   (long-horizon autoregressive rollout)
@@ -23,7 +23,7 @@ docs/
 - **[Configuration system](config_system.md)** — Hydra layout, composition, environment variables, common overrides, debugging.
 - **[Training](training.md)** — workflow + the four design axes (prediction target, action injection, model scale, EMA) with ablation tables and pretrained checkpoints.
 - **[Evaluation](evaluation.md)** — `experiment=evaluate_only`, scheduling modes, metric definitions, headline numbers on each domain.
-- **[Datasets](datasets/README.md)** — DINO-WM (5 envs), RT-1 fractal, CSGO. Download / split / format / config.
+- **[Datasets](datasets/README.md)** — DINO-WM (5 envs), RT-1 fractal, CSGO, BlockWorld. Download / split / format / config.
 - **[Planning](applications/planning.md)** — MPC + CEM over the diffusion world model. point_maze and PushT recipes.
 - **[Long rollout](applications/long_rollout.md)** — 50-frame autoregressive rollout with sliding context window. CSGO demo.
 - **[Video → 3D point cloud](applications/video_to_3d.md)** — DA3 multi-view depth + viser viewer.

--- a/docs/config_system.md
+++ b/docs/config_system.md
@@ -164,6 +164,12 @@ Each dataset family has a `base.yaml` that fixes the schema, plus per-dataset ov
 #             action_dim=51 (keys + mouse), normalize_action=False
 ```
 
+**Memory** (`src/configs/dataset/memory/`):
+```yaml
+# blockworld.yaml — FlowM 3D BlockWorld memory benchmark,
+#                   train_slice_mode=random, action_dim=5 one-hot actions
+```
+
 **RT-1** (`src/configs/dataset/rt1/`):
 ```yaml
 # rt1.yaml — LeRobot HF dataset (IPEC-COMMUNITY/fractal20220817_data_lerobot),

--- a/docs/datasets/README.md
+++ b/docs/datasets/README.md
@@ -1,6 +1,6 @@
 # Datasets
 
-The repo ships configs for three dataset families: **DINO-WM** (5 simulated environments), **RT-1 fractal** (real-robot LeRobot), and **CSGO** (Counter-Strike deathmatch). All datasets feed through a common `WorldModelDataset` interface — see `src/wm_datasets/`.
+The repo ships configs for four dataset families: **DINO-WM** (5 simulated environments), **RT-1 fractal** (real-robot LeRobot), **CSGO** (Counter-Strike deathmatch), and **BlockWorld** (FlowM 3D memory benchmark). All datasets feed through a common `WorldModelDataset` interface — see `src/wm_datasets/`.
 
 <div align="center">
 
@@ -15,6 +15,8 @@ export DATASET_DIR=/path/to/dino_wm_data       # DINO-WM root
 export CSGO_DATA_DIR=/path/to/csgo             # CSGO root (HDF5 files)
 export RT1_DATA_ROOT=/path/to/rt1_fractal      # RT-1 (LeRobot mirror)
 ```
+
+For BlockWorld, set `DATASET_DIR` to the parent directory containing `blockworld/`.
 
 Or use the gitignored `src/configs/local/paths.yaml` (template at `paths.yaml.example`). See [config_system.md](../config_system.md#path-configuration).
 
@@ -31,6 +33,7 @@ Or use the gitignored `src/configs/local/paths.yaml` (template at `paths.yaml.ex
 | DINO-WM Granular | ~500 | ~100–200 | 256² | 2 | exhaustive | deformable |
 | RT-1 (fractal) | 87k | ~40–60 | 256² | 7 | random | LeRobot v2.0, frame_interval=1 |
 | CSGO | 5500 | 1000 | 320×512 | 51 | random | fixed val start indices, frame_interval=1 |
+| BlockWorld | config-dependent | 70–140 | 128² | 5 | random | FlowM 3D memory benchmark |
 
 </div>
 
@@ -198,6 +201,65 @@ The shipped checkpoints are NanoWM-L/2 trained for 50k or 100k steps. See [train
 - Actions: ~10 MB/episode (cached in memory)
 - Frames: ~123 MB/episode (loaded on demand — never cached)
 - Total: ~675 GB on disk; RAM stays bounded by the per-batch decode
+
+---
+
+## BlockWorld
+
+FlowM's 3D Dynamic BlockWorld memory benchmark. Source: [hlillemark/flowm](https://github.com/hlillemark/flowm). The dataset uses RGB videos plus per-frame discrete actions; nano-world-model exposes those actions as 5-D one-hot vectors.
+
+### Download
+
+Use the FlowM dataset downloader and place the extracted dataset under `${DATASET_DIR}/blockworld`:
+
+```bash
+cd /path/to/flowm
+bash ./download_datasets.sh --dataset blockworld --configs dynamic --splits train,validation
+```
+
+### Data format
+
+Expected layout:
+
+```text
+${DATASET_DIR}/blockworld/
+├── sunday_v2_training/
+│   └── 0/
+│       ├── 0000_rgb.mp4
+│       ├── 0000_depth.mp4
+│       └── 0000_actions.pt
+└── sunday_v2_validation/
+```
+
+The `*_actions.pt` sidecar must contain either an `actions` tensor of integer action ids or an already-vectorized `[T, 5]` tensor. Depth videos are left untouched; the current integration is RGB-only to match the existing NanoWM video/action interface.
+
+### Config
+
+`src/configs/dataset/memory/blockworld.yaml`:
+
+```yaml
+name: "blockworld"
+frame_interval: 1
+loader:
+  data_path_train: "${dataset_dir}/blockworld/sunday_v2_training"
+  data_path_val: "${dataset_dir}/blockworld/sunday_v2_validation"
+  normalize_action: False
+  train_slice_mode: "random"
+  val_slice_mode: "exhaustive"
+spec:
+  action_dim: 5
+```
+
+### Train command
+
+```bash
+python src/main.py dataset=memory/blockworld model=nanowm_b2
+```
+
+### Memory
+
+- Actions are small and cached on first trajectory access.
+- Frames are decoded on demand from MP4 and are never cached by the data source.
 
 ---
 

--- a/src/configs/dataset/memory/base.yaml
+++ b/src/configs/dataset/memory/base.yaml
@@ -1,0 +1,20 @@
+# @package dataset
+loader:
+  n_rollout: null
+  data_path_train: null
+  data_path_val: null
+  split_ratio: 0.9
+  validation_size: 32
+  normalize_state: False
+  normalize_action: False
+  train_slice_mode: "random"
+  val_slice_mode: "exhaustive"
+  stride: 1
+  random_seed: 42
+  validation_fixed_subset_path: null
+  validation_fixed_subset_size: null
+  validation_fixed_subset_seed: 42
+  file_list: null
+  action_dim: 5
+  video_suffix: "_rgb.mp4"
+  action_suffix: "_actions.pt"

--- a/src/configs/dataset/memory/blockworld.yaml
+++ b/src/configs/dataset/memory/blockworld.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - memory/base
+
+name: "blockworld"
+frame_interval: 1
+
+loader:
+  data_path_train: "${dataset_dir}/blockworld/sunday_v2_training"
+  data_path_val: "${dataset_dir}/blockworld/sunday_v2_validation"
+  normalize_action: False
+  resize_mode: "stretch"
+  train_slice_mode: "random"
+  val_slice_mode: "exhaustive"
+  action_dim: 5
+
+spec:
+  action_dim: 5

--- a/src/wm_datasets/README.md
+++ b/src/wm_datasets/README.md
@@ -77,6 +77,7 @@ train_dataset, val_dataset = create_train_val_datasets(
 | **pusht** | 18,685 | 5 | 2 | ~109 |
 | **rope** | TBD | TBD | TBD | TBD |
 | **granular** | TBD | TBD | TBD | TBD |
+| **blockworld** | config-dependent | 0 | 5 | 70–140 |
 
 </div>
 
@@ -130,6 +131,7 @@ def create_world_model_dataset(
 - `use_relative_actions` (pusht): Use relative vs absolute actions
 - `action_scale` (pusht): Action scaling factor
 - `object_name` (deformable): "rope" or "granular"
+- `action_dim` (blockworld): Number of discrete actions for one-hot encoding
 
 ### Sampling Modes
 

--- a/src/wm_datasets/__init__.py
+++ b/src/wm_datasets/__init__.py
@@ -9,6 +9,7 @@ This module provides a unified data loading pipeline with three layers:
 
 from .data_source import (
     DataSource,
+    BlockWorldDataSource,
     DinoWorldModelDataSource,
     LeRobotDataSource,
     TrajectoryData,
@@ -25,6 +26,7 @@ from .world_model_dataset import (
 __all__ = [
     # DataSource layer
     "DataSource",
+    "BlockWorldDataSource",
     "DinoWorldModelDataSource",
     "LeRobotDataSource",
     "TrajectoryData",

--- a/src/wm_datasets/data_source/__init__.py
+++ b/src/wm_datasets/data_source/__init__.py
@@ -5,6 +5,7 @@ DataSource package for world model datasets.
 from .base import DataSource, TrajectoryData
 from .dino_wm import DinoWorldModelDataSource, PushTDataSource, DeformableEnvDataSource
 from .lerobot import LeRobotDataSource
+from .memory import BlockWorldDataSource
 from .factory import create_data_source
 
 __all__ = [
@@ -14,5 +15,6 @@ __all__ = [
     "PushTDataSource",
     "DeformableEnvDataSource",
     "LeRobotDataSource",
+    "BlockWorldDataSource",
     "create_data_source",
 ]

--- a/src/wm_datasets/data_source/factory.py
+++ b/src/wm_datasets/data_source/factory.py
@@ -7,6 +7,7 @@ from typing import Optional
 from .dino_wm import DinoWorldModelDataSource, PushTDataSource, DeformableEnvDataSource
 from .lerobot import LeRobotDataSource
 from .game import CSGODataSource
+from .memory import BlockWorldDataSource
 from .base import DataSource
 
 
@@ -72,7 +73,18 @@ def create_data_source(
             **csgo_kwargs
         )
 
+    if dataset_name == "blockworld":
+        blockworld_kwargs = {
+            k: v for k, v in kwargs.items()
+            if k in ['action_dim', 'file_list', 'video_suffix', 'action_suffix']
+        }
+        return BlockWorldDataSource(
+            data_path=data_path,
+            n_rollout=n_rollout,
+            **blockworld_kwargs,
+        )
+
     raise ValueError(
         f"Unknown dataset: {dataset_name}. "
-        f"Supported: point_maze, wall, pusht, rope, granular, rt1, csgo"
+        f"Supported: point_maze, wall, pusht, rope, granular, rt1, csgo, blockworld"
     )

--- a/src/wm_datasets/data_source/memory/__init__.py
+++ b/src/wm_datasets/data_source/memory/__init__.py
@@ -1,0 +1,7 @@
+"""
+Memory benchmark dataset sources.
+"""
+
+from .blockworld_data_source import BlockWorldDataSource
+
+__all__ = ["BlockWorldDataSource"]

--- a/src/wm_datasets/data_source/memory/blockworld_data_source.py
+++ b/src/wm_datasets/data_source/memory/blockworld_data_source.py
@@ -1,0 +1,242 @@
+"""
+FlowM BlockWorld data source for 3D memory benchmark episodes.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from ..base import DataSource, TrajectoryData
+
+
+class BlockWorldDataSource(DataSource):
+    """
+    Data source for FlowM Dynamic BlockWorld episodes.
+
+    Expected directory structure:
+        data_path/
+        ├── sunday_v2_training/
+        │   └── 0/
+        │       ├── 0000_rgb.mp4
+        │       ├── 0000_depth.mp4
+        │       └── 0000_actions.pt
+        ├── sunday_v2_validation/
+        ├── sunday_v2_static_training/
+        ├── sunday_v2_static_validation/
+        ├── tex_training/
+        └── tex_validation/
+
+    The companion action file is a torch object with an ``actions`` entry.
+    Integer actions are converted to one-hot vectors to match the
+    nano-world-model action-conditioning interface.
+    """
+
+    def __init__(
+        self,
+        data_path: str,
+        n_rollout: Optional[int] = None,
+        action_dim: int = 5,
+        file_list: Optional[str] = None,
+        video_suffix: str = "_rgb.mp4",
+        action_suffix: str = "_actions.pt",
+    ) -> None:
+        """Create a BlockWorld data source from a split or dataset root."""
+        self.data_path = Path(data_path).expanduser()
+        self._action_dim = int(action_dim)
+        self.file_list = file_list
+        self.video_suffix = video_suffix
+        self.action_suffix = action_suffix
+
+        if self._action_dim <= 0:
+            raise ValueError(f"action_dim must be positive, got {self._action_dim}")
+        if not self.data_path.exists():
+            raise FileNotFoundError(f"BlockWorld data path not found: {self.data_path}")
+
+        self._episodes = self._discover_episodes(file_list=file_list)
+        if n_rollout is not None:
+            self._episodes = self._episodes[:n_rollout]
+        if not self._episodes:
+            raise FileNotFoundError(
+                f"No BlockWorld videos matching '*{self.video_suffix}' found in {self.data_path}"
+            )
+
+        self._action_cache: Dict[int, torch.Tensor] = {}
+
+        print(f"Loaded {len(self._episodes)} BlockWorld episodes")
+        print(f"  Action dim: {self._action_dim}, State dim: 0 (pure vision)")
+
+    def _discover_episodes(self, file_list: Optional[str]) -> List[Tuple[str, Path, Path]]:
+        """Find RGB videos and their companion action files."""
+        if file_list is None:
+            video_paths = sorted(self.data_path.rglob(f"*{self.video_suffix}"), key=str)
+        else:
+            video_paths = self._load_file_list(file_list)
+
+        episodes: List[Tuple[str, Path, Path]] = []
+        for video_path in video_paths:
+            action_path = self._action_path_from_video(video_path)
+            if not action_path.exists():
+                raise FileNotFoundError(
+                    f"Missing BlockWorld action file for {video_path}: expected {action_path}"
+                )
+            relative_path = video_path.relative_to(self.data_path).as_posix()
+            episodes.append((relative_path, video_path, action_path))
+        return episodes
+
+    def _load_file_list(self, file_list: str) -> List[Path]:
+        """Load explicit video paths from a file list."""
+        file_list_path = Path(file_list).expanduser()
+        if not file_list_path.is_absolute():
+            file_list_path = Path.cwd() / file_list_path
+        if not file_list_path.exists():
+            raise FileNotFoundError(f"BlockWorld file list not found: {file_list_path}")
+
+        video_paths: List[Path] = []
+        with open(file_list_path, "r") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                path = Path(line)
+                if not path.is_absolute():
+                    path = self.data_path / path
+                video_paths.append(path)
+        return sorted(video_paths, key=str)
+
+    def _action_path_from_video(self, video_path: Path) -> Path:
+        """Return the FlowM action sidecar path for an RGB video path."""
+        stem = video_path.stem
+        if stem.endswith("_rgb"):
+            stem = stem[:-4]
+        return video_path.with_name(f"{stem}{self.action_suffix}")
+
+    def _load_actions(self, index: int) -> torch.Tensor:
+        """Load and cache one episode's action sequence."""
+        if index not in self._action_cache:
+            _, _, action_path = self._episodes[index]
+            payload = torch.load(action_path, map_location=torch.device("cpu"), weights_only=False)
+            if isinstance(payload, dict):
+                if "actions" not in payload:
+                    raise KeyError(f"BlockWorld action file has no 'actions' key: {action_path}")
+                actions = payload["actions"]
+            else:
+                actions = payload
+
+            self._action_cache[index] = self._format_actions(actions, action_path)
+        return self._action_cache[index]
+
+    def _format_actions(self, actions: torch.Tensor, action_path: Path) -> torch.Tensor:
+        """Convert integer or vector actions into float action vectors."""
+        actions = torch.as_tensor(actions)
+        if actions.ndim == 1:
+            if actions.numel() == 0:
+                raise ValueError(f"BlockWorld action file is empty: {action_path}")
+            action_ids = actions.long()
+            min_action = int(action_ids.min().item())
+            max_action = int(action_ids.max().item())
+            if min_action < 0 or max_action >= self._action_dim:
+                raise ValueError(
+                    f"BlockWorld actions in {action_path} must be in [0, {self._action_dim}); "
+                    f"found [{min_action}, {max_action}]"
+                )
+            return F.one_hot(action_ids, num_classes=self._action_dim).float()
+
+        if actions.ndim == 2:
+            if actions.shape[-1] == 1:
+                return self._format_actions(actions.squeeze(-1), action_path)
+            if actions.shape[-1] != self._action_dim:
+                raise ValueError(
+                    f"BlockWorld action vectors in {action_path} have dim {actions.shape[-1]}, "
+                    f"expected {self._action_dim}"
+                )
+            return actions.float()
+
+        raise ValueError(
+            f"BlockWorld actions in {action_path} must have shape [T] or [T, {self._action_dim}], "
+            f"got {tuple(actions.shape)}"
+        )
+
+    def load_trajectory(self, index: int) -> TrajectoryData:
+        """Load metadata and actions for the trajectory at the given index."""
+        if index >= len(self._episodes):
+            raise IndexError(f"Index {index} out of range [0, {len(self._episodes)})")
+
+        actions = self._load_actions(index)
+        states = torch.zeros(actions.shape[0], 0, dtype=torch.float32)
+        relative_path, _, _ = self._episodes[index]
+        return TrajectoryData(
+            states=states,
+            actions=actions,
+            seq_length=actions.shape[0],
+            meta={"episode_id": relative_path},
+        )
+
+    def load_visual_frames(
+        self,
+        index: int,
+        start: int,
+        end: int,
+        step: int = 1,
+    ) -> torch.Tensor:
+        """Load RGB frames for a specific trajectory and time range."""
+        if index >= len(self._episodes):
+            raise IndexError(f"Index {index} out of range [0, {len(self._episodes)})")
+
+        _, video_path, _ = self._episodes[index]
+        frame_indices = list(range(start, end, step))
+        try:
+            from decord import VideoReader, cpu
+
+            reader = VideoReader(str(video_path), ctx=cpu(0))
+            if frame_indices and frame_indices[-1] >= len(reader):
+                raise ValueError(
+                    f"Frame index {frame_indices[-1]} exceeds video length {len(reader)} for {video_path}"
+                )
+
+            frames = reader.get_batch(frame_indices)
+            if not isinstance(frames, torch.Tensor):
+                if hasattr(frames, "asnumpy"):
+                    frames = frames.asnumpy()
+                frames = torch.as_tensor(frames)
+        except ImportError:
+            frames = self._load_visual_frames_with_imageio(video_path, frame_indices)
+        return frames.float().permute(0, 3, 1, 2).contiguous() / 255.0
+
+    def _load_visual_frames_with_imageio(self, video_path: Path, frame_indices: List[int]) -> torch.Tensor:
+        """Load RGB frames with imageio when decord is unavailable."""
+        try:
+            import imageio.v2 as imageio
+        except ImportError as exc:
+            raise ImportError(
+                "BlockWorld video loading requires decord or imageio. Install the "
+                "nano-world-model environment before training or evaluation."
+            ) from exc
+
+        reader = imageio.get_reader(video_path)
+        try:
+            frames = [torch.as_tensor(reader.get_data(i)) for i in frame_indices]
+        finally:
+            reader.close()
+        return torch.stack(frames, dim=0)
+
+    def get_num_trajectories(self) -> int:
+        """Return total number of trajectories in this data source."""
+        return len(self._episodes)
+
+    def get_seq_length(self, index: int) -> int:
+        """Return sequence length without loading video frames."""
+        if index >= len(self._episodes):
+            raise IndexError(f"Index {index} out of range [0, {len(self._episodes)})")
+        return int(self._load_actions(index).shape[0])
+
+    @property
+    def action_dim(self) -> int:
+        """Return the one-hot BlockWorld action dimension."""
+        return self._action_dim
+
+    @property
+    def state_dim(self) -> int:
+        """Return the state dimension; BlockWorld is exposed as pure vision."""
+        return 0

--- a/src/wm_datasets/world_model_dataset.py
+++ b/src/wm_datasets/world_model_dataset.py
@@ -705,6 +705,7 @@ def create_world_model_dataset(
     datasource_params = {
         'use_relative_actions', 'action_scale', 'object_name',
         'file_list', 'use_auxiliary_state',  # file_list is for CSGO DataSource
+        'action_dim', 'video_suffix', 'action_suffix',  # BlockWorld DataSource
         'root', 'image_key', 'preload_trajectories', 'pad_action_dim',  # LeRobotDataSource
     }
     for key, value in kwargs.items():
@@ -998,6 +999,7 @@ def create_eval_only_dataset(
     datasource_params = {
         'use_relative_actions', 'action_scale', 'object_name',
         'file_list', 'use_auxiliary_state',
+        'action_dim', 'video_suffix', 'action_suffix',
         'root', 'image_key', 'preload_trajectories', 'pad_action_dim',
     }
     for key, value in kwargs.items():


### PR DESCRIPTION
## Summary

This PR adds dataset support for FlowM's 3D Dynamic BlockWorld memory benchmark through nano-world-model's existing dataset/data-source interface.

Original code repo: https://github.com/hlillemark/flowm
Paper link: https://arxiv.org/abs/2601.01075

The integration is intentionally minimal:
- adds a `BlockWorldDataSource` under `wm_datasets.data_source.memory`
- registers `dataset=memory/blockworld`
- exposes FlowM discrete actions as 5-D one-hot action vectors
- loads RGB MP4 frames through the existing `WorldModelDataset` video/action path
- documents the expected data layout and training command

Depth videos are left untouched for now; this PR only wires the RGB/action path needed by NanoWM training.

## Dataset Layout

Expected layout:

```text
${DATASET_DIR}/blockworld/
├── sunday_v2_training/
│   └── 0/
│       ├── 0000_rgb.mp4
│       ├── 0000_depth.mp4
│       └── 0000_actions.pt
└── sunday_v2_validation/
```

`*_actions.pt` may contain either integer action ids or already-vectorized `[T, 5]` actions.

## Usage

```bash
python src/main.py dataset=memory/blockworld model=nanowm_b2
```

## Validation

I validated the integration with synthetic BlockWorld-style episodes matching the expected RGB MP4 + action sidecar layout.

### Dataset and config smoke

```text
$ python -m unittest tests.test_blockworld_data_source
....
----------------------------------------------------------------------
Ran 4 tests in 0.813s

OK
```

```text
$ python -m py_compile \
  src/wm_datasets/data_source/memory/blockworld_data_source.py \
  src/wm_datasets/data_source/factory.py \
  src/wm_datasets/data_source/__init__.py \
  src/wm_datasets/world_model_dataset.py
```

```text
$ python -c "... compose dataset=memory/blockworld model=nanowm_b2 ..."
blockworld
./data/blockworld/sunday_v2_training
./data/blockworld/sunday_v2_validation
5
```

### Model loss smoke

Built NanoWM with the BlockWorld dataset config and `action_dim=5`, then ran the diffusion training loss and backward pass.

```text
model_arch NanoWM-S/8
action_dim 5
loss 0.9845133423805237
backward_ok True
```

### Full training smoke

Ran a one-step training smoke through the repo's normal `src/main.py` entrypoint with synthetic BlockWorld-style data.

Command shape:

```bash
python src/main.py \
  dataset=memory/blockworld \
  model=nanowm_s2 \
  model.num_frames=2 \
  model.image_size=32 \
  model.latent_size=8 \
  experiment.training.max_steps=1 \
  experiment.training.batch_size=1 \
  experiment.infra.num_workers=0 \
  experiment.infra.compile=false \
  experiment.infra.mixed_precision=false \
  experiment.evaluation.metrics.evaluate=false \
  experiment.evaluation.save_videos=false \
  wandb.enabled=false
```

Relevant output:

```text
Loaded 2 BlockWorld episodes
  Action dim: 5, State dim: 0 (pure vision)
Split 'train': 2 trajectories (random sampling mode)

Loaded 1 BlockWorld episodes
  Action dim: 5, State dim: 0 (pure vision)
Creating slices (exhaustive mode, stride=1) from 1 trajectories...
Created 5 slices total
Split 'val': 5 slices

[Data] Datasets created
[Init] NanoWMTrainingModule: building model
[Init] VAE loaded, scaling_factor=0.18215, vae_precision=fp32
[Init] VAE sanity: clean under vae_precision=fp32
[Init] NanoWMTrainingModule initialized
[Data] DataLoaders created

(step=0000001/epoch=0000) Train Loss: 0.2491, Gradient Norm: 0.0000
val_loss=0.511
```

Also ran:

```text
$ git diff --check
```

No whitespace errors were reported.

### Out-of-tree validation snippet

The following focused validation file was used to check the integration with synthetic BlockWorld-style episodes. It is not included in this PR.

<details>
<summary>Validation file used locally</summary>

```python
"""
Tests for the FlowM BlockWorld memory benchmark data source.
"""

import sys
import types
import unittest
from pathlib import Path
from tempfile import TemporaryDirectory
from unittest.mock import patch

import torch
import imageio.v2 as imageio
import numpy as np

ROOT = Path(__file__).resolve().parents[1]
sys.path.insert(0, str(ROOT / "src"))

if "decord" not in sys.modules:
    decord_stub = types.SimpleNamespace(
        VideoReader=object,
        bridge=types.SimpleNamespace(set_bridge=lambda *_args, **_kwargs: None),
    )
    sys.modules["decord"] = decord_stub
if "h5py" not in sys.modules:
    sys.modules["h5py"] = types.SimpleNamespace(File=object)

from wm_datasets import create_train_val_datasets
from wm_datasets.data_source import create_data_source


class BlockWorldDataSourceTest(unittest.TestCase):
    """Verify that FlowM BlockWorld episodes match the nano-world-model interface."""

    def test_integer_actions_are_exposed_as_one_hot_actions(self) -> None:
        """Load FlowM-style integer actions as 5-D one-hot action vectors."""
        with TemporaryDirectory() as tmpdir:
            self._write_episode(Path(tmpdir) / "sunday_v2_training" / "0", [0, 1, 2, 4])

            source = create_data_source("blockworld", data_path=tmpdir)
            trajectory = source.load_trajectory(0)

            self.assertEqual(source.get_num_trajectories(), 1)
            self.assertEqual(source.action_dim, 5)
            self.assertEqual(source.state_dim, 0)
            self.assertEqual(trajectory.seq_length, 4)
            self.assertEqual(tuple(trajectory.actions.shape), (4, 5))
            self.assertTrue(torch.equal(trajectory.actions[0], torch.tensor([1, 0, 0, 0, 0]).float()))
            self.assertTrue(torch.equal(trajectory.actions[3], torch.tensor([0, 0, 0, 0, 1]).float()))
            self.assertEqual(trajectory.meta["episode_id"], "sunday_v2_training/0/0000_rgb.mp4")

    def test_train_val_factory_accepts_split_paths(self) -> None:
        """Create WorldModelDataset train/val splits from FlowM split directories."""
        with TemporaryDirectory() as tmpdir:
            root = Path(tmpdir) / "blockworld"
            self._write_episode(root / "sunday_v2_training" / "0", [0, 1, 2, 4])
            self._write_episode(root / "sunday_v2_validation" / "0", [4, 2, 1, 0])

            train_dataset, val_dataset = create_train_val_datasets(
                dataset_name="blockworld",
                data_path_train=str(root / "sunday_v2_training"),
                data_path_val=str(root / "sunday_v2_validation"),
                num_frames=2,
                normalize_action=False,
                train_slice_mode="random",
                val_slice_mode="exhaustive",
                action_dim=5,
            )

            self.assertEqual(train_dataset.action_dim, 5)
            self.assertEqual(val_dataset.action_dim, 5)
            self.assertEqual(len(train_dataset), 1)
            self.assertEqual(len(val_dataset), 3)

    def test_world_model_dataset_loads_video_and_action_clip(self) -> None:
        """Decode RGB frames through WorldModelDataset.__getitem__."""
        with TemporaryDirectory() as tmpdir:
            root = Path(tmpdir) / "blockworld"
            self._write_episode(root / "sunday_v2_training" / "0", [0, 1, 2, 4], write_video=True)
            self._write_episode(root / "sunday_v2_validation" / "0", [4, 2, 1, 0], write_video=True)

            _, val_dataset = create_train_val_datasets(
                dataset_name="blockworld",
                data_path_train=str(root / "sunday_v2_training"),
                data_path_val=str(root / "sunday_v2_validation"),
                num_frames=2,
                image_size=(8, 8),
                normalize_action=False,
                normalize_pixel=True,
                train_slice_mode="random",
                val_slice_mode="exhaustive",
                action_dim=5,
            )

            sample = val_dataset[0]

            self.assertEqual(tuple(sample["video"].shape), (2, 3, 8, 8))
            self.assertEqual(tuple(sample["action"].shape), (2, 5))
            self.assertEqual(sample["video"].dtype, torch.float32)
            self.assertGreaterEqual(float(sample["video"].min()), -1.0)
            self.assertLessEqual(float(sample["video"].max()), 1.0)
            self.assertTrue(torch.equal(sample["action"][0], torch.tensor([0, 0, 0, 0, 1]).float()))

    def test_decord_torch_bridge_frames_are_supported(self) -> None:
        """Decode decord torch-bridge tensors without calling NDArray.asnumpy."""
        with TemporaryDirectory() as tmpdir:
            self._write_episode(Path(tmpdir) / "sunday_v2_training" / "0", [0, 1, 2])
            source = create_data_source("blockworld", data_path=tmpdir)

            class TorchBridgeVideoReader:
                """Minimal decord VideoReader stub that returns torch tensors."""

                def __init__(self, _video_path: str, ctx: object | None = None) -> None:
                    """Accept the same arguments used by BlockWorldDataSource."""
                    self._frames = torch.full((3, 4, 5, 3), 255, dtype=torch.uint8)

                def __len__(self) -> int:
                    """Return the synthetic video length."""
                    return self._frames.shape[0]

                def get_batch(self, frame_indices: list[int]) -> torch.Tensor:
                    """Return a torch tensor like decord's torch bridge."""
                    return self._frames[frame_indices]

            decord_stub = types.SimpleNamespace(
                VideoReader=TorchBridgeVideoReader,
                cpu=lambda _index: object(),
            )
            with patch.dict(sys.modules, {"decord": decord_stub}):
                frames = source.load_visual_frames(0, 0, 2)

            self.assertEqual(tuple(frames.shape), (2, 3, 4, 5))
            self.assertTrue(torch.allclose(frames, torch.ones_like(frames)))

    def _write_episode(
        self,
        episode_dir: Path,
        actions: list[int],
        write_video: bool = False,
    ) -> None:
        """Write a minimal FlowM-style episode directory for tests."""
        episode_dir.mkdir(parents=True)
        video_path = episode_dir / "0000_rgb.mp4"
        if write_video:
            frames = []
            for i in range(len(actions)):
                frame = np.full((16, 16, 3), i * 32, dtype=np.uint8)
                frame[:, :, 0] = 255 - i * 32
                frames.append(frame)
            imageio.mimwrite(video_path, frames, fps=4, codec="libx264")
        else:
            video_path.touch()
        torch.save({"actions": torch.tensor(actions)}, episode_dir / "0000_actions.pt")


if __name__ == "__main__":
    unittest.main()
```

</details>
