### PR TITLE
Fix rollout.py for DINO-WM envs (point_maze / pusht / wall)

### DIFF
--- a/src/sample/rollout.py
+++ b/src/sample/rollout.py
@@ -170,7 +170,7 @@ def main(args):
 
             # Normalize actions if the dataset was configured to do so
             if dataset.normalize_action:
-                raw_actions = (raw_actions - dataset.action_mean) / dataset.action_std
+                raw_actions = (raw_actions - dataset._raw_action_mean) / dataset._raw_action_std
 
             batch_visual_list.append(visual_frames)
             batch_raw_actions_list.append(raw_actions)

--- a/src/wm_datasets/data_source/dino_wm/dino_world_model.py
+++ b/src/wm_datasets/data_source/dino_wm/dino_world_model.py
@@ -211,6 +211,9 @@ class DinoWorldModelDataSource(DataSource):
 
         return frames
 
+    def get_seq_length(self, index: int) -> int:
+        return int(self.seq_lengths[index].item())
+
     def get_num_trajectories(self) -> int:
         return self.num_trajectories
 


### PR DESCRIPTION
Fixes #8.

## Changes

1. **Add `get_seq_length` to `DinoWorldModelDataSource`.** One-line method returning `int(self.seq_lengths[index].item())`, mirroring the same method on `LerobotDataSource`. This is the method `rollout.py` already calls.

2. **Use `_raw_action_mean` / `_raw_action_std` in `rollout.py`'s pre-rearrange action normalization.** `dataset.action_mean` is broadcast to `[frame_interval × action_dim]` inside `_broadcast_action_stats` and is meant for post-rearrange tensors. At this point in `rollout.py`, raw actions are still `[F, action_dim]`, so we want the unbroadcast stats — matching what the dataset's own `__getitem__` uses (`world_model_dataset.py:582`).

## Tested

Ran `src/sample/rollout.py` on `nanowm-b2-dino-wm-point-maze-30k` (Colab T4, 2 samples × 20 rollout frames × 25 DDIM steps, `--history_length 3`) — produces the expected `*_gen.mp4` / `*_gt.mp4` / `*_compare.mp4` per sample.