### PR TITLE
Pass weights_only=False to torch.load in find_model

### DIFF
--- a/src/utils/nanowm_utils.py
+++ b/src/utils/nanowm_utils.py
@@ -253,7 +253,7 @@ def find_model(model_name):
     Finds a pre-trained NanoWM model, downloading it if necessary. Alternatively, loads a model from a local path.
     """
     assert os.path.isfile(model_name), f'Could not find NanoWM checkpoint at {model_name}'
-    checkpoint = torch.load(model_name, map_location=lambda storage, loc: storage)
+    checkpoint = torch.load(model_name, map_location=lambda storage, loc: storage, weights_only=False)
         
     if "state_dict" in checkpoint:  # supports PyTorch Lightning checkpoints
         print('Using state_dict (PyTorch Lightning)!')


### PR DESCRIPTION
Fixes #10.

## Change

`src/utils/nanowm_utils.find_model` calls `torch.load` without specifying `weights_only`. PyTorch 2.6 (Jan 2025) changed that default from `False` to `True`, breaking checkpoint loading on any modern install. Pass it explicitly.

```diff
- checkpoint = torch.load(model_name, map_location=lambda storage, loc: storage)
+ checkpoint = torch.load(model_name, map_location=lambda storage, loc: storage, weights_only=False)
```

## Why `weights_only=False` is safe here

The official checkpoints come from the project's own HuggingFace org (`knightnemo/nanowm-*`). They're not user-supplied untrusted blobs, so the relaxed pickle loading is appropriate.

If stricter loading is desired long-term, a follow-up could ship checkpoints as `safetensors` and update `find_model` to detect the format — but that's a larger change. This one-liner restores the documented `find_model` behavior on current PyTorch.

## Tested

Loaded `nanowm-b2-dino-wm-point-maze-30k` on Colab T4 with PyTorch 2.6 (after converting the released `model.safetensors` to `.pt`) and ran a full rollout successfully.